### PR TITLE
Do not ignore all files that start with a dot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ target
 Gemfile.lock
 
 autotest
-.*
 
 felix-cache
+
+# IntelliJ IDEA
+/.idea/
+/*.iml


### PR DESCRIPTION
That ignores .gitignore itself as well as the committed .rspec and
.travis.yml files. Instead, ignore typical IntelliJ IDEA files.