### PR TITLE
Remove Gemfile.lock from packaged gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -40,7 +40,6 @@ namespace :naether do
       FileUtils.copy( 'VERSION', "target/gem/VERSION" )
       FileUtils.copy( 'PostInstallRakefile', "target/gem/Rakefile" )
       FileUtils.copy( 'Gemfile', "target/gem/Gemfile" )
-      FileUtils.copy( 'Gemfile.lock', "target/gem/Gemfile.lock" )
 
       version = IO.read('VERSION').strip
       if !File.exists? "target/core-#{version}.jar"


### PR DESCRIPTION
The `Gemfile.lock` that is packaged in the gem is raising some false alarms in an OTS static analysis tool. Normally, a packaged gem won't have a `Gemfile.lock`. It would be great to a get a new release and patch-level version bump, if you have the time. Thank you!